### PR TITLE
Improved console output on startup

### DIFF
--- a/cnapy/CNA_MEngine.py
+++ b/cnapy/CNA_MEngine.py
@@ -95,7 +95,7 @@ try:
             return self.cplex_java_ready
 
 except:
-    print('Octave is not available.')
+    print('CNApy running without Octave enabled.')
 
 
 def run_tests():


### PR DESCRIPTION
I have rephrased Octave not available -> CNApy running without Octave enabled